### PR TITLE
Fix ARIA tree navigation for hidden items

### DIFF
--- a/public/a11y-req.js
+++ b/public/a11y-req.js
@@ -251,11 +251,18 @@ var showRemoved = function () {
     e.preventDefault();
     $('#clauses input:not(:checked)').each(function () {
       var $element = $(this).closest('[role="treeitem"]');
-      $element.removeClass('hidden').removeAttr('aria-hidden');
+      $element.removeClass('hidden');
     });
     $('.disabledClauses').removeClass('hidden');
     $('.disabledClauses').text("Disable clauses are now shown.")
     setTimeout(function () { $('.disabledClauses').addClass('hidden'); }, 500);
+    
+    // Update the ARIA tree visibility after showing items
+    if (window.trees && window.trees.length > 0) {
+      for (var i = 0; i < window.trees.length; i++) {
+        window.trees[i].updateVisibvarreeitems();
+      }
+    }
   });
 }
 
@@ -307,12 +314,19 @@ var hideRemoved = function () {
     $('#clauses input:not(:checked)').each(function () {
       if (!$(this).prop('indeterminate')) {
         var $element = $(this).closest('[role="treeitem"]');
-        $element.addClass('hidden').attr('aria-hidden', 'true');
+        $element.addClass('hidden');
       }
     });
     $('.disabledClauses').removeClass('hidden');
     $('.disabledClauses').text("Disable clauses are now hidden.");
     setTimeout(function () { $('.disabledClauses').addClass('hidden'); }, 500);
+    
+    // Update the ARIA tree visibility after hiding items
+    if (window.trees && window.trees.length > 0) {
+      for (var i = 0; i < window.trees.length; i++) {
+        window.trees[i].updateVisibvarreeitems();
+      }
+    }
   });
 }
 
@@ -901,19 +915,26 @@ var step4Handler = function () {
       // Checkbox is in indeterminate state
       $this.siblings('span.remove-text').text('');
       $this.siblings('span').css('color', '#333333');
-      $checkboxContainer.removeClass('hidden').removeAttr('aria-hidden');
+      $checkboxContainer.removeClass('hidden');
     } else if ($this.is(':checked')) {
       // Checkbox is checked
       $this.siblings('span.remove-text').text('');
       $this.siblings('span').css('color', '#333333');
-      $checkboxContainer.removeClass('hidden').removeAttr('aria-hidden');
+      $checkboxContainer.removeClass('hidden');
     } else {
       // Checkbox is not checked
       $this.siblings('span.remove-text').text('[removed]  ');
       $this.siblings('span').css('color', '#AD0000');
-      $checkboxContainer.addClass('hidden').attr('aria-hidden', 'true');
+      $checkboxContainer.addClass('hidden');
     }
   });
+  
+  // Update the ARIA tree visibility after hiding/showing items
+  if (window.trees && window.trees.length > 0) {
+    for (var i = 0; i < window.trees.length; i++) {
+      window.trees[i].updateVisibvarreeitems();
+    }
+  }
 }
 
 // Call the setup function to initialize the handler

--- a/public/a11y-req.js
+++ b/public/a11y-req.js
@@ -250,8 +250,8 @@ var showRemoved = function () {
   $('#showAllRemovedClauses').click(function (e) {
     e.preventDefault();
     $('#clauses input:not(:checked)').each(function () {
-      var $element = $(this).closest('.checkbox');
-      $element.removeClass('hidden');
+      var $element = $(this).closest('[role="treeitem"]');
+      $element.removeClass('hidden').removeAttr('aria-hidden');
     });
     $('.disabledClauses').removeClass('hidden');
     $('.disabledClauses').text("Disable clauses are now shown.")
@@ -306,8 +306,8 @@ var hideRemoved = function () {
     e.preventDefault();
     $('#clauses input:not(:checked)').each(function () {
       if (!$(this).prop('indeterminate')) {
-        var $element = $(this).closest('.checkbox');
-        $element.addClass('hidden');
+        var $element = $(this).closest('[role="treeitem"]');
+        $element.addClass('hidden').attr('aria-hidden', 'true');
       }
     });
     $('.disabledClauses').removeClass('hidden');
@@ -327,15 +327,13 @@ var selectAll = function () {
 };
 
 var clauseCounter = function () {
-  // Just to count total number of clauses can be removed afterwards
   var totalClauses = 0
   $('#clauses input:checked').each(function () {
     if (($(this).closest('li').hasClass('endNode')) && !($(this).closest('li').hasClass('informative'))) {
       totalClauses++;
     }
   });
-
-  $('.clause-count').html("<strong>Total number of clause applicable: " + totalClauses + "</strong>");
+  $('.clauseCount').text(totalClauses);
 }
 
 var updateWizard = function () {
@@ -898,22 +896,22 @@ var step3QuestionHandler = function () {
 var step4Handler = function () {
   $('#clauses input').each(function () {
     var $this = $(this);
-    var $checkboxContainer = $this.closest('.checkbox');
+    var $checkboxContainer = $this.closest('[role="treeitem"]');
     if ($this.prop('indeterminate')) {
       // Checkbox is in indeterminate state
       $this.siblings('span.remove-text').text('');
       $this.siblings('span').css('color', '#333333');
-      $checkboxContainer.removeClass('hidden');
+      $checkboxContainer.removeClass('hidden').removeAttr('aria-hidden');
     } else if ($this.is(':checked')) {
       // Checkbox is checked
       $this.siblings('span.remove-text').text('');
       $this.siblings('span').css('color', '#333333');
-      $checkboxContainer.removeClass('hidden');
+      $checkboxContainer.removeClass('hidden').removeAttr('aria-hidden');
     } else {
       // Checkbox is not checked
       $this.siblings('span.remove-text').text('[removed]  ');
       $this.siblings('span').css('color', '#AD0000');
-      $checkboxContainer.addClass('hidden');
+      $checkboxContainer.addClass('hidden').attr('aria-hidden', 'true');
     }
   });
 }

--- a/public/aria-tree.js
+++ b/public/aria-tree.js
@@ -31,10 +31,14 @@ $(document).on("wb-updated.wb-tabs", ".wb-tabs", function (event, $newPanel) {
 $(document).on("wb-ready.wb", function (event) {
 
   var trees = document.querySelectorAll('[role="tree"]');
+  
+  // Store trees globally so other code can update visibility
+  window.trees = [];
 
   for (var i = 0; i < trees.length; i++) {
     var t = new Tree(trees[i]);
     t.init();
+    window.trees.push(t);
   }
 
 });
@@ -223,6 +227,11 @@ Tree.prototype.updateVisibvarreeitems = function () {
     var parent = ti.domNode.parentNode;
 
     ti.isVisible = true;
+
+    // Check if this treeitem is hidden with the 'hidden' class
+    if (ti.domNode.classList.contains('hidden')) {
+      ti.isVisible = false;
+    }
 
     while (parent && (parent !== this.domNode)) {
 
@@ -731,9 +740,10 @@ var updateAriaChecked = function ($node) {
   }
   $node[0].setAttribute('aria-checked', checked);
   // Application specific: Parent node might have an informative child
-  if ($node.is('.parentNode')) {
-    selectInformative($node);
-  }
+// this has been disabled to support negative selection. the data currently doesn't require logic like this in step 4, but if we find a bug or need it in the future consider adapting the below to make it work.
+//  if ($node.is('.parentNode')) {
+//    selectInformative($node);
+//  }
 };
 
 // Application specific: Select child informative clauses automatically


### PR DESCRIPTION
- Modified ARIA tree logic to respect .hidden class for navigation
- Updated step4Handler to target [role='treeitem'] instead of .checkbox
- Removed aria-hidden usage to prevent tabindex conflicts
- Added tree visibility updates after hiding/showing clauses
- Ensures hidden clauses don't interfere with keyboard navigation

Fixes accessibility issue where JAWS reads hidden content and resolves tabindex=0 conflicts during keyboard navigation.